### PR TITLE
Add `rand` feature to allow disabling of `rand` dep in favor of `getrandom`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,17 @@ readme = "README.md"
 [badges]
 maintenance = { status = "actively-developed"}
 
+[features]
+default = ["rand"]
+rand = ["dep:rand"]
+
 [dependencies]
-rand = "0.8.5"
+getrandom = "0.2"
+rand = { version = "0.8.5", optional = true }
 siphasher = "1.0.0"
 wide = "0.7.15"
 
 [dev-dependencies]
+rand = "0.8.5"
 rand_regex = "0.16.0"
 ahash = "0.8.6"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ getrandom = { version = "0.2", features = ["js"] }
 
 This applies to whether you are using the default `rand` hash initialization or the fallback `getrandom` entropy sourcing.
 
+## Available Features
+
+- **`rand`** - Enabled by default, this has the `DefaultHasher` source its random state using `thread_rng()` instead of hardware sources. Getting entropy from a user-space source is considerably faster, but requires additional dependencies to achieve this. Disabling this feature by using `default-features = false` makes `DefaultHasher` source its entropy using `getrandom`, which will have a much simpler code footprint at the expense of speed.
+
 ## References
 - [Bloom filter - Wikipedia](https://en.wikipedia.org/wiki/Bloom_filter)
 - [Bloom Filter - Brilliant](https://brilliant.org/wiki/bloom-filter/)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ Note:
 
 In reality, the Bloom filter may have more than 64 bits of storage. In that case, many underlying `u64`s in the block are operated on using SIMD intrinsics. The number of hashes is adjusted to be the number of hashes per `u64` in the block. Additionally, some bits may be set in the usual way to account for any rounding errors.
 
+## WASM Support on the web
+
+To enable support for WASM on web platforms, `getrandom` needs to be configured to support the browser environment. Add the following to your project's `Cargo.toml`:
+
+```toml
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+```
+
+This applies to whether you are using the default `rand` hash initialization or the fallback `getrandom` entropy sourcing.
+
 ## References
 - [Bloom filter - Wikipedia](https://en.wikipedia.org/wiki/Bloom_filter)
 - [Bloom Filter - Brilliant](https://brilliant.org/wiki/bloom-filter/)

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use siphasher::sip::SipHasher13;
 use std::hash::{BuildHasher, Hasher};
 
@@ -49,11 +48,19 @@ impl RandomDefaultHasher {
 impl Default for RandomDefaultHasher {
     #[inline]
     fn default() -> Self {
-        let mut rng = rand::thread_rng();
         let mut seed = [0u8; 16];
-        for b in seed.iter_mut() {
-            *b = rng.gen();
+
+        #[cfg(not(feature = "rand"))]
+        {
+            getrandom::getrandom(&mut seed).expect("Unable to source entropy from OS/Hardware sources");
         }
+        #[cfg(feature = "rand")]
+        {
+            use rand::RngCore;
+
+            rand::thread_rng().fill_bytes(&mut seed);
+        }
+
         Self::seeded(&seed)
     }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -52,7 +52,8 @@ impl Default for RandomDefaultHasher {
 
         #[cfg(not(feature = "rand"))]
         {
-            getrandom::getrandom(&mut seed).expect("Unable to source entropy from OS/Hardware sources");
+            getrandom::getrandom(&mut seed)
+                .expect("Unable to obtain entropy from OS/Hardware sources");
         }
         #[cfg(feature = "rand")]
         {


### PR DESCRIPTION
Not sure if you accept PRs, but I was interested in your crate and decided to have a look to understand a few things. In the process, saw a couple of things that could be improved or to offer some options for different use-cases. Even if this doesn't get merged, it could serve as some food for thought for this repo.

If I understand correctly, you are using `rand` to have a faster randomised state initialisation for your `DefaultHasher`. However, `rand` brings in a fair amount of code to do what it does, and some cases might want to reduce the dependency burden by not relying on `rand` for sourcing entropy. In this PR, I put it behind a feature flag (enabled by default), so that for most cases, it is being used but can at least be opted out in favour of `getrandom` (which `rand` uses as well to initialise its PRNGs). With there being a feature flag now, I added a note about this on the README.

I added a note on WASM support as well, so that folks know how to enable it regardless of whether they are using `rand` feature or not (since `getrandom` is used either way).

As the default is to use `rand`, this PR is not a breaking change (as it should maintain the current status quo for its usage), though this is also not a public API consideration.

Feature names or what text should say is subject to further bikeshedding if needed.