### PR TITLE
fix multiply with overflow error in i686-msvc-windows environment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ pub(crate) fn get_orginal_hashes(
 /// <https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/>
 #[inline]
 pub(crate) fn block_index(num_blocks: usize, hash: u64) -> usize {
-    (((hash >> 32) as usize * num_blocks) >> 32) as usize
+    (((hash >> 32) * num_blocks as u64) >> 32) as usize
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses an integer overflow issue that occurs in the i686-msvc-windows environment. The problem arises in the block_index function due to the calculation expression ((hash >> 32) as usize * num_blocks) >> 32.

In a 32-bit environment, the usize type is 32 bits in size and can represent values up to 2^32 - 1. However, this calculation expression may result in a value that exceeds the representation range of the usize type, causing an overflow error.