### PR TITLE
add support for rust version 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fastbloom"
 version = "0.7.1"
 edition = "2021"
+rust-version = "1.70.0"
 authors = ["tomtomwombat"]
 description = "The fastest Bloom filter in Rust. No accuracy compromises. Compatible with any hasher."
 license = "MIT OR Apache-2.0"
@@ -31,5 +32,5 @@ wide = "0.7.15"
 
 [dev-dependencies]
 rand = "0.8.5"
-rand_regex = "0.16.0"
+rand_regex = "0.15.1"
 ahash = "0.8.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,9 @@ impl BloomFilter {
         num_bits: usize,
     ) -> BuilderWithBits<BLOCK_SIZE_BITS> {
         assert!(num_bits > 0);
-        let num_u64s = num_bits.div_ceil(64);
+        // Only available in rust 1.73+
+        // let num_u64s = num_bits.div_ceil(64);
+        let num_u64s = (num_bits + 64 - 1) / 64;
         BuilderWithBits::<BLOCK_SIZE_BITS> {
             data: vec![0; num_u64s],
             hasher: Default::default(),


### PR DESCRIPTION
And adds msrv to 1.70.0 

We are now building our application on a platform that only support 1.70.0 (for now). This PR makes a few changes to support 1.70.0 and adds `rust-version` to the manifest to enable MSRV. 
