### PR TITLE
Upgrade to rand v0.9 & getrandom v0.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,8 @@ jobs:
       run: cargo llvm-cov --doctests --verbose --lcov --output-path lcov.info
       env:
         CARGO_INCREMENTAL: '0'
-        RUSTFLAGS: '-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-        RUSTDOCFLAGS: '-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+        RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+        RUSTDOCFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Zunstable-options --persist-doctests target/debug/doctestbins'
     - name: Codecov
       uses: codecov/codecov-action@v4-beta
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,16 +20,15 @@ jobs:
       with:
         toolchain: nightly
         override: true
+    - uses: taiki-e/install-action@cargo-llvm-cov
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo cargo llvm-cov --doctests --verbose --lcov --output-path lcov.info
       env:
         CARGO_INCREMENTAL: '0'
-        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-    - name: rust-grcov
-      uses: actions-rs/grcov@v0.1
+        RUSTFLAGS: '-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+        RUSTDOCFLAGS: '-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
     - name: Codecov
       uses: codecov/codecov-action@v4-beta
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,17 +18,21 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: stable
         override: true
     - uses: taiki-e/install-action@cargo-llvm-cov
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
-      run: cargo llvm-cov --doctests --verbose --lcov --output-path lcov.info
+    - name: Run doctests
+      run: cargo test --doc --verbose
       env:
         CARGO_INCREMENTAL: '0'
-        RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-        RUSTDOCFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Zunstable-options --persist-doctests target/debug/doctestbins'
+        RUSTDOCFLAGS: '-Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort'
+    - name: Run tests with coverage
+      run: cargo llvm-cov --verbose --lcov --output-path lcov.info
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort'
     - name: Codecov
       uses: codecov/codecov-action@v4-beta
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo cargo llvm-cov --doctests --verbose --lcov --output-path lcov.info
+      run: cargo llvm-cov --doctests --verbose --lcov --output-path lcov.info
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,12 +27,12 @@ jobs:
       run: cargo test --doc --verbose
       env:
         CARGO_INCREMENTAL: '0'
-        RUSTDOCFLAGS: '-Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort'
+        RUSTDOCFLAGS: '-Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
     - name: Run tests with coverage
       run: cargo llvm-cov --verbose --lcov --output-path lcov.info
       env:
         CARGO_INCREMENTAL: '0'
-        RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort'
+        RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
     - name: Codecov
       uses: codecov/codecov-action@v4-beta
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ rand = ["dep:rand"]
 serde = ["dep:serde", "siphasher/serde_std"]
 
 [dependencies]
-getrandom = "0.2"
-rand = { version = "0.8.5", optional = true }
+getrandom = "0.3"
+rand = { version = "0.9.0", optional = true }
 serde = { version = "1.0.203", features = ["derive"], optional = true }
 siphasher = "1.0.0"
 wide = "0.7.15"
 
 [dev-dependencies]
-rand = "0.8.5"
-rand_regex = "0.15.1"
+rand = "0.9"
+rand_regex = "0.18"
 ahash = "0.8.6"

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -132,11 +132,11 @@ mod tests {
     fn test_only_random_inserts_are_contained() {
         let mut vec = BlockedBitVec::<64>::from(vec![0; 80]);
         let mut control = HashSet::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         for _ in 0..100000 {
-            let block_index = rng.gen_range(0..vec.num_blocks());
-            let bit_index = rng.gen_range(0..64);
+            let block_index = rng.random_range(0..vec.num_blocks());
+            let bit_index = rng.random_range(0..64);
 
             let block = vec.get_block(block_index);
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -54,13 +54,11 @@ impl Default for RandomDefaultHasher {
 
         #[cfg(not(feature = "rand"))]
         {
-            getrandom::getrandom(&mut seed)
-                .expect("Unable to obtain entropy from OS/Hardware sources");
+            getrandom::fill(&mut seed).expect("Unable to obtain entropy from OS/Hardware sources");
         }
         #[cfg(feature = "rand")]
         {
             use rand::RngCore;
-
             rand::rng().fill_bytes(&mut seed);
         }
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -61,7 +61,7 @@ impl Default for RandomDefaultHasher {
         {
             use rand::RngCore;
 
-            rand::thread_rng().fill_bytes(&mut seed);
+            rand::rng().fill_bytes(&mut seed);
         }
 
         Self::seeded(&seed)

--- a/src/sparse_hash.rs
+++ b/src/sparse_hash.rs
@@ -340,8 +340,8 @@ mod test {
             let trials = 10_000;
             let mut total_bits = 0;
             for _ in 0..trials {
-                let mut h1 = rng.gen();
-                let h2 = rng.gen();
+                let mut h1 = rng.random();
+                let h2 = rng.random();
                 let h = u64::sparse_hash(&mut h1, h2, target_bits);
                 total_bits += h.count_ones();
             }


### PR DESCRIPTION
Pretty straightforward PR, since `rand` and `getrandom` have new major versions, this crate should be updated to support them. I've gone and renamed various methods away from their deprecated versions to their new recommended ones (which will be compatible with Rust 2024 edition, given the `gen` keyword is now reserved going forward).

I also made some changes here and there to silence clippy warnings, but everything should pass the tests and compile just fine. This will necessitate publishing a new major version for `fastbloom` after this PR is merged.