### PR TITLE
Enforce MSRV in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,3 +40,13 @@ jobs:
       with:
         verbose: true
         fail_ci_if_error: true
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.70"
+          override: true
+      - run: cargo check --lib --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fastbloom"
 version = "0.12.1"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.70"
 authors = ["tomtomwombat"]
 description = "The fastest Bloom filter in Rust. No accuracy compromises. Compatible with any hasher."
 license = "MIT OR Apache-2.0"

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -9,23 +9,23 @@ const BIT_MASK: u64 = (1 << BIT_MASK_LEN) - 1;
 /// A bit vector partitioned in to `u64` blocks.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BlockedBitVec {
+pub(crate) struct BlockedBitVec {
     bits: Box<[u64]>,
 }
 
 impl BlockedBitVec {
     #[inline]
-    pub const fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.bits.len()
     }
 
     #[inline]
-    pub const fn num_bits(&self) -> usize {
+    pub(crate) const fn num_bits(&self) -> usize {
         self.len() * u64::BITS as usize
     }
 
     #[inline]
-    pub fn set(&mut self, index: usize, hash: u64) -> bool {
+    pub(crate) fn set(&mut self, index: usize, hash: u64) -> bool {
         let bit = 1u64 << (hash & BIT_MASK);
         let previously_contained = self.bits[index] & bit > 0;
         self.bits[index] |= bit;
@@ -33,18 +33,18 @@ impl BlockedBitVec {
     }
 
     #[inline]
-    pub const fn check(&self, index: usize, hash: u64) -> bool {
+    pub(crate) const fn check(&self, index: usize, hash: u64) -> bool {
         let bit = 1u64 << (hash & BIT_MASK);
         self.bits[index] & bit > 0
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u64] {
+    pub(crate) fn as_slice(&self) -> &[u64] {
         &self.bits
     }
 
     #[inline]
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         for i in 0..self.bits.len() {
             self.bits[i] = 0;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(rustdoc::bare_urls)]
+#![warn(unreachable_pub)]
 #![doc = include_str!("../README.md")]
 
 use std::hash::{BuildHasher, Hash, Hasher};


### PR DESCRIPTION
This crate advertises a 1.70 MSRV but generates this error:

```rust
error[E0658]: mutable references are not allowed in constant functions
  --> src/bit_vector.rs:28:22
   |
28 |     pub const fn set(&mut self, index: usize, hash: u64) -> bool {
   |                      ^^^^^^^^^
   |
   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
```

This only works from 1.82 on.

In Quinn, we prefer to be more conservative about the MSRV (currently at 1.71, though we're bumping to 1.74 soon) so if there's a way to decrease it again, that would be nice.