### PR TITLE
fix: correct `AtomicBitVec::set` behaviour

### DIFF
--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -126,9 +126,7 @@ impl AtomicBitVec {
     #[inline(always)]
     pub(crate) fn set(&self, index: usize) -> bool {
         let (index, bit) = coord(index);
-        let previously_contained = self.bits[index].load(Relaxed) & bit > 0;
-        self.bits[index].fetch_or(bit, Relaxed);
-        previously_contained
+        self.bits[index].fetch_or(bit, Relaxed) & bit > 0
     }
 
     #[inline]


### PR DESCRIPTION
In original code `set` performs `load` and `fetch_or` afterwards. But if two threads simulteniously perform `set` it possible that no one would observe `true` as result of `set` operation.

We can avoid using `load` and just `fetch_or` and check `fetch`ed value.