### PR TITLE
fix no-std support (replace getrandom)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ maintenance = { status = "actively-developed" }
 default = ["std", "rand"]
 std = []
 loom = ["dep:loom"]
-rand = ["dep:rand"]
+rand = ["std", "dep:rand"]
 serde = ["dep:serde", "siphasher/serde_std"]
 
 [dependencies]
-getrandom = "0.3"
+foldhash = { version = "0.2.0", default-features = false }
 loom = { version = "0.7.2", optional = true }
 rand = { version = "0.9.0", optional = true }
 serde = { version = "1.0.203", features = ["derive"], optional = true }
-siphasher = "1.0.0"
+siphasher = { version = "1.0.0", default-features = false }
 libm = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
currently, even when "std" feature is not selected, various std features are still used by various crates.

rand - rand::rng() finally requires "std", so make the "rand" feature automatically select it.

siphasher - disable default features.

getrandom - has no-std support (when its default features are not enabled), but it might actually link against various libs that might not be available
(e.g. bcryptprimitives.dll - https://github.com/rust-random/getrandom/issues/65)

replace it with foldhash and concat 2 random u64 hashes in order to generate 128-bit seed.